### PR TITLE
Fix routing and associated action for joining event

### DIFF
--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -3,7 +3,7 @@ class AttendancesController < ApplicationController
 
   def create
     @user = current_user
-    @event = Event.find_by(id: params[:event_id])
+    @event = Event.find_by(id: params[:attendance][:event_id])
     @attendance = Attendance.new(attendance_params)
     begin
       @attendance.save
@@ -11,7 +11,8 @@ class AttendancesController < ApplicationController
       flash[:danger] = "You are already in this event"
       render "users/show"
     else
-      redirect_to event_path(@event)
+      flash[:success] = "You are now part of this event! Nice"
+      redirect_to @event
     end
   end
 

--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -1,15 +1,24 @@
 class AttendancesController < ApplicationController
-  
+  before_action :logged_in_user, only: :create
+
   def create
-    @event = Event.find_by(id: params[:id])
+    @user = current_user
+    @event = Event.find_by(id: params[:event_id])
+    @attendance = Attendance.new(attendance_params)
     begin
-      @event.add_attendee(current_user)
+      @attendance.save
     rescue => exception
       flash[:danger] = "You are already in this event"
       render "users/show"
     else
-      redirect_to @event
+      redirect_to event_path(@event)
     end
+  end
+
+  private
+
+  def attendance_params
+    params.require(:attendance).permit(:attendee_id, :event_id)
   end
 
 end

--- a/app/views/attendances/_join_form.html.erb
+++ b/app/views/attendances/_join_form.html.erb
@@ -1,0 +1,5 @@
+<%= simple_form_for Attendance.new do |f|%>
+  <%= f.hidden_field :event_id, value: @event.id%>
+  <%= f.hidden_field :attendee_id, value: current_user.id if logged_in? %>
+  <%= f.button :submit, "Join Event", class:"btn-primary" %>
+<% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -19,7 +19,7 @@
       <h4>Event ended</h4>
     <% else %>
       <% if !@event.attendees.include? current_user %>
-        <%= link_to "Attend Event", join_event_path, class: "btn btn-primary" %>
+        <%= render "attendances/join_form"%>
       <% else %>
         <h4>You are attending this event</h4>
       <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,1 +1,1 @@
-<%= render  "user" %>
+<%= render  "users/user" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,11 +5,12 @@ Rails.application.routes.draw do
   get "login", to: "sessions#new"
   post "login", to: "sessions#create"
   get "logout", to: "sessions#destroy"
-  get "/events/:id/join", to: "attendances#create", as: "join_event"
   
   resources :users do
     resources :events, only: [:new, :edit, :create, :destroy]
   end
   
   resources :events, only: [:index, :show, :update]
+
+  resources :attendances, only: :create
 end


### PR DESCRIPTION
1. Transferred logic for joining an event from events_controller into attendances_controller -> Into its own 'create' action.

2. Created an 'attendance' resource in routes only for create action

3. Created a join_event_form partial that only includes a join button and 2 hidden input fields corresponding to event_id and attendee_id

